### PR TITLE
Support listing branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ var fileInfo = status["src/newFile.json"];
 
 ```
 
+### Get branches
+
+Using the **GetBranches()** method to retrieve the local branches of the current repository.
+
+```csharp
+var repos = new GitRepository(@"D:\TestSample");
+var status = repos.GetBranches();
+
+Console.WriteLine("Branches:");
+foreach (var branch in branches)
+{
+    Console.WriteLine($"{branch}");
+}
+```
+
+To retrieve the remote branches use the **GetBranches(bool)** method with the value "true" ("false" will retrieve the local branches).
+
+```csharp
+var repos = new GitRepository(@"D:\TestSample");
+var status = repos.GetBranches(true);
+
+Console.WriteLine("Remote branches:");
+foreach (var branch in branches)
+{
+    Console.WriteLine($"{branch}");
+}
+```
+
 ### Staging/Restore
 
 To stage the current work tree use any of the **Stage/Add/Restore** methods.

--- a/tests/HansPeterGit.Tests/GitBranchesTests.cs
+++ b/tests/HansPeterGit.Tests/GitBranchesTests.cs
@@ -1,0 +1,55 @@
+using NUnit.Framework;
+
+namespace HansPeterGit.Tests;
+
+[TestFixture]
+public class GitBranchesTests
+{
+    [Test]
+    public void GetBranchesTest()
+    {
+        var repos = new GitRepository(".");
+        var branches = repos.GetBranches();
+
+        var branchesArray = branches as string[] ?? branches.ToArray();
+
+        Assert.That(branchesArray, Is.Not.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(branchesArray.Any(branch => branch == string.Empty), Is.False);
+            Assert.That(branchesArray, Contains.Item("main"));
+        });
+    }
+
+    [Test]
+    public void GetRemoteBranchesTest()
+    {
+        var repos = new GitRepository(".");
+        var branches = repos.GetBranches(true);
+
+        var branchesArray = branches as string[] ?? branches.ToArray();
+
+        Assert.That(branchesArray, Is.Not.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(branchesArray.Any(branch => branch == string.Empty), Is.False);
+            Assert.That(branchesArray.Any(branch => branch.Contains("origin/HEAD")), Is.True);
+        });
+    }
+
+    [Test]
+    public void GetLocalBranchesTest()
+    {
+        var repos = new GitRepository(".");
+        var branches = repos.GetBranches(true);
+
+        var branchesArray = branches as string[] ?? branches.ToArray();
+
+        Assert.That(branchesArray, Is.Not.Empty);
+        Assert.Multiple(() =>
+        {
+            Assert.That(branchesArray.Any(branch => branch == string.Empty), Is.False);
+            Assert.That(branchesArray.Any(branch => branch.Contains("origin/HEAD")), Is.True);
+        });
+    }
+}


### PR DESCRIPTION
To implement issue #2 I added a GetBranches() method to retrieve an enumerable with the local branch names. An overloaded version is also available to retrieve the remove branch names. Use the GetBranches(bool) version with "true" to retrieve the remote branches.
The unit tests should check the correct behaviour of the methods. Both methods are described in the README file.